### PR TITLE
Remove undefined check for findMatchString call

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -536,7 +536,7 @@ angular.module('angucomplete-alt', [] )
               image = extractValue(responseData[i], scope.imageField);
             }
 
-            if (scope.matchClass && typeof str !== 'undefined') {
+            if (scope.matchClass) {
               formattedText = findMatchString(text, str);
               formattedDesc = findMatchString(description, str);
             }


### PR DESCRIPTION
The method marks the input as sanitized. When skipped, the code fails with "Attempting to use an unsafe value in a safe context." from `$sce`.
